### PR TITLE
Prevented unexpected exit: handle SIGPIPE properly

### DIFF
--- a/src/CoreArbiterServer.cc
+++ b/src/CoreArbiterServer.cc
@@ -1572,7 +1572,7 @@ void signalHandler(int signum) {
         }).detach();
     } else if ((signum == SIGSEGV) || (signum == SIGABRT)) {
         invokeGDB(signum);
-    } 
+    }
 }
 
 /**

--- a/src/CoreArbiterServer.cc
+++ b/src/CoreArbiterServer.cc
@@ -409,7 +409,9 @@ bool CoreArbiterServer::handleEvents()
             timeoutThreadPreemption(socket);
             sys->epoll_ctl(epollFd, EPOLL_CTL_DEL,
                            socket, &events[i]);
-            sys->close(socket);
+            if (sys->close(socket) < 0) {
+                LOG(ERROR, "Error closing socket: %s", strerror(errno));
+            }
         } else if (socket == terminationFd) {
             return false;
         } else {
@@ -805,15 +807,17 @@ CoreArbiterServer::timeoutThreadPreemption(int timerFd)
 void
 CoreArbiterServer::cleanupConnection(int socket)
 {
-    sys->close(socket);
     if (threadSocketToInfo.find(socket) == threadSocketToInfo.end()) {
-        LOG(WARNING, "Unknown thread");
         return;
     }
     ThreadInfo* thread = threadSocketToInfo[socket];
     ProcessInfo* process = thread->process;
 
     LOG(NOTICE, "Cleaning up state for thread %d", thread->id);
+
+    if (sys->close(socket) < 0) {
+        LOG(ERROR, "Error closing socket: %s", strerror(errno));
+    }
 
     // We'll only distribute cores at the end if necessary
     bool shouldDistributeCores = false;
@@ -858,7 +862,9 @@ CoreArbiterServer::cleanupConnection(int socket)
     if (noRemainingThreads) {
         LOG(NOTICE, "All of process %d's threads have exited. Removing all "
             "process records.\n", process->id);
-        sys->close(process->sharedMemFd);
+        if (sys->close(process->sharedMemFd) < 0) {
+            LOG(ERROR, "Error closing sharedMemFd: %s", strerror(errno));
+        }
         processIdToInfo.erase(process->id);
 
         // Remove this process from the core priority queue

--- a/src/CoreArbiterServer.cc
+++ b/src/CoreArbiterServer.cc
@@ -805,7 +805,10 @@ CoreArbiterServer::timeoutThreadPreemption(int timerFd)
 void
 CoreArbiterServer::cleanupConnection(int socket)
 {
-    sys->close(socket);
+    if (sys->close(socket) == -1) {
+        // The socket was closed before, just return
+        return;
+    }
     ThreadInfo* thread = threadSocketToInfo[socket];
     ProcessInfo* process = thread->process;
 
@@ -1067,12 +1070,12 @@ CoreArbiterServer::distributeCores()
                     if (!sendData(thread->socket, &core->id, sizeof(int),
                                   "Error sending core ID to thread " +
                                         std::to_string(thread->id))) {
-                        // TODO(Qian): is it a good solution to ignore error?
                         // The client side did not close TCP connection 
-                        // in a normal way, which caused the failure
-                        LOG(WARNING, "Pending to clean up state for thread %s",
-                            std::to_string(thread->id).c_str());
-                        continue;
+                        // in a normal way, which caused the failure.
+                        // Then we just clean up the connection here.
+                        sys->epoll_ctl(epollFd, EPOLL_CTL_DEL,
+                                       thread->socket, NULL);
+                        cleanupConnection(thread->socket);
                     }
                     // TimeTrace::record("SERVER: Finished sending wakeup\n");
                     LOG(DEBUG, "Sent wakeup");
@@ -1565,7 +1568,6 @@ void signalHandler(int signum) {
     } else if (signum == SIGPIPE) {
         // Ignore SIGPIPE and allow repeated invocations
         signalAction.sa_handler = signalHandler;
-        signalAction.sa_flags = 0;
         sigaction(signum, &signalAction, NULL);
         LOG(WARNING, "Received SIGPIPE: connection was not closed normally");
         return;
@@ -1590,9 +1592,6 @@ CoreArbiterServer::installSignalHandler() {
         LOG(ERROR, "Couldn't set signal handler for SIGSEGV");
     if (sigaction(SIGABRT, &signalAction, NULL) != 0)
         LOG(ERROR, "Couldn't set signal handler for SIGABRT");
-
-    // Set sa_flags to 0 to ensure the function fail
-    signalAction.sa_flags = 0;
     if (sigaction(SIGPIPE, &signalAction, NULL) != 0)
         LOG(ERROR, "Couldn't set signal handler for SIGPIPE");
 }

--- a/src/CoreArbiterServerMain.cc
+++ b/src/CoreArbiterServerMain.cc
@@ -106,7 +106,7 @@ parseOptions(int* argcp, const char** argv) {
 }
 
 int main(int argc, const char** argv) {
-    Logger::setLogLevel(CoreArbiter::ERROR);
+    Logger::setLogLevel(CoreArbiter::NOTICE);
     parseOptions(&argc, argv);
     printf("socketPath:       %s\n", socketPath.c_str());
     printf("sharedMemoryPath: %s\n", sharedMemoryPath.c_str());
@@ -118,6 +118,7 @@ int main(int argc, const char** argv) {
             printf(" %d", coresUsed[i]);
         putchar('\n');
     }
+    fflush(stdout);
 
     CoreArbiterServer server(socketPath,
                              sharedMemoryPath,

--- a/src/CoreArbiterServerMain.cc
+++ b/src/CoreArbiterServerMain.cc
@@ -106,7 +106,7 @@ parseOptions(int* argcp, const char** argv) {
 }
 
 int main(int argc, const char** argv) {
-    Logger::setLogLevel(CoreArbiter::NOTICE);
+    Logger::setLogLevel(CoreArbiter::ERROR);
     parseOptions(&argc, argv);
     printf("socketPath:       %s\n", socketPath.c_str());
     printf("sharedMemoryPath: %s\n", sharedMemoryPath.c_str());

--- a/src/Logger.cc
+++ b/src/Logger.cc
@@ -64,6 +64,7 @@ void Logger::log(const CodeLocation& where, LogLevel level,
         fprintf(stderr, "%s\n", buffer);
     } else {
         printf("%s\n", buffer);
+        fflush(stdout);
     }
 }
 

--- a/src/Logger.cc
+++ b/src/Logger.cc
@@ -20,6 +20,7 @@ namespace CoreArbiter {
 
 using PerfUtils::Cycles;
 
+FILE* Logger::errorStream = stderr;
 LogLevel Logger::displayMinLevel = NOTICE;
 std::mutex Logger::mutex;
 
@@ -60,12 +61,8 @@ void Logger::log(const CodeLocation& where, LogLevel level,
     va_end(args);
 
     Lock lock(mutex);
-    if (level == ERROR) {
-        fprintf(stderr, "%s\n", buffer);
-    } else {
-        printf("%s\n", buffer);
-        fflush(stdout);
-    }
+    fprintf(errorStream, "%s\n", buffer);
+    fflush(errorStream);
 }
 
 } // namespace CoreArbiter

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -51,7 +51,6 @@ class Logger {
         errorStream = stream;
     }
 
-
     /**
      * Print a message to the console at a given severity level. Accepts
      * printf-style format strings.

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -44,6 +44,15 @@ class Logger {
     }
 
     /**
+      * Change the target of the error stream, allowing redirection to an
+      * application's log.
+      */
+    static void setErrorStream(FILE* stream) {
+        errorStream = stream;
+    }
+
+
+    /**
      * Print a message to the console at a given severity level. Accepts
      * printf-style format strings.
      *
@@ -63,6 +72,9 @@ class Logger {
     // Lock around printing since CoreArbiterClient has threads.
     typedef std::unique_lock<std::mutex> Lock;
     static std::mutex mutex;
+
+    // Used to allow redirection of error messages.
+    static FILE* errorStream;
 };
 
 } //namespace CoreArbiter


### PR DESCRIPTION
We found that CoreArbiter server sometimes crashed due to SIGPIPE. This signal often caused by writing to a broken TCP connection, which means the application that uses Arachne did not close the connection correctly (e.g., the application crashed without closing the connection). 

Thus, a temporary solution is to ignore `SIGPIPE` and the `sendData()` error, then the CoreArbiter server would eventually detect the closed connection and clean up the thread state.