### PR TITLE
Add return value check for reading timerFd

### DIFF
--- a/src/CoreArbiterServer.cc
+++ b/src/CoreArbiterServer.cc
@@ -755,8 +755,9 @@ CoreArbiterServer::timeoutThreadPreemption(int timerFd)
         uint64_t time;
         ssize_t ret = read(timerFd, &time, sizeof(uint64_t));
         if (ret == -1) {
-            LOG(ERROR, "Error reading time: %s", strerror(errno));
-            return;
+            LOG(ERROR, "Error reading number of expirations of the timer: %s",
+                strerror(errno));
+            exit(1);
         }
     }
 

--- a/src/CoreArbiterServer.cc
+++ b/src/CoreArbiterServer.cc
@@ -753,7 +753,11 @@ CoreArbiterServer::timeoutThreadPreemption(int timerFd)
 {
     if (!testingSkipSocketCommunication) {
         uint64_t time;
-        read(timerFd, &time, sizeof(uint64_t));
+        ssize_t ret = read(timerFd, &time, sizeof(uint64_t));
+        if (ret == -1) {
+            LOG(ERROR, "Error reading time: %s", strerror(errno));
+            return;
+        }
     }
 
     struct TimerInfo* timer = &timerFdToInfo[timerFd];


### PR DESCRIPTION
If return value is -1, then log the error and return.