### PR TITLE
Prevent multiple CoreArbiterServer instances using advisory lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ TEST_LIBS=-Lobj/ -lCoreArbiter $(OBJECT_DIR)/libgtest.a
 INCLUDE+=-I${GTEST_DIR}/include
 
 test: $(OBJECT_DIR)/CoreArbiterServerTest $(OBJECT_DIR)/CoreArbiterClientTest
-	sudo $(OBJECT_DIR)/CoreArbiterServerTest
+	$(OBJECT_DIR)/CoreArbiterServerTest
 	$(OBJECT_DIR)/CoreArbiterClientTest
 
 $(OBJECT_DIR)/CoreArbiterServerTest: $(OBJECT_DIR)/CoreArbiterServerTest.o $(OBJECT_DIR)/libgtest.a $(OBJECT_DIR)/libCoreArbiter.a

--- a/src/CoreArbiterServer.h
+++ b/src/CoreArbiterServer.h
@@ -266,6 +266,13 @@ class CoreArbiterServer {
     // information (see the GlobalStats struct below).
     int globalSharedMemFd;
 
+    // The path to the advisory lock file, preventing multi
+    // coreArbiterServer instances
+    std::string advisoryLockPath;
+
+    // The file descriptor for the advisory lock file
+    int advisoryLockFd;
+
     // Pointer to a struct in shared memory that contains global information
     // about the state of all processes connected to this server.
     struct GlobalStats* stats;

--- a/src/CoreArbiterServerTest.cc
+++ b/src/CoreArbiterServerTest.cc
@@ -152,6 +152,12 @@ TEST_F(CoreArbiterServerTest, endArbitration) {
     arbitrationThread.join();
 }
 
+TEST_F(CoreArbiterServerTest, advisoryLock) {
+    CoreArbiterServer server(socketPath, memPath, {1, 2}, false);
+    ASSERT_DEATH(CoreArbiterServer(socketPath, memPath, {1, 2}, false),
+                 "Error acquiring advisory lock:.*");
+}
+
 TEST_F(CoreArbiterServerTest, defaultCores) {
     CoreArbiterServer::testingSkipCpusetAllocation = true;
 

--- a/src/Syscall.h
+++ b/src/Syscall.h
@@ -21,6 +21,7 @@
 #include <linux/futex.h>
 #include <netinet/in.h>
 #include <sys/epoll.h>
+#include <sys/file.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -180,6 +181,7 @@ class Syscall {
     virtual ssize_t write(int fd, const void* buf, size_t count) {
         return ::write(fd, buf, count);
     }
+    virtual int flock(int fd, int operation) { return ::flock(fd, operation); }
 };
 
 /**

--- a/src/Syscall.h
+++ b/src/Syscall.h
@@ -181,6 +181,10 @@ class Syscall {
     virtual ssize_t write(int fd, const void* buf, size_t count) {
         return ::write(fd, buf, count);
     }
+    virtual ssize_t read(int fd, void* buf, size_t count) {
+        return ::read(fd, buf, count);
+    }
+
     virtual int flock(int fd, int operation) { return ::flock(fd, operation); }
 };
 


### PR DESCRIPTION
CoreArbiterServer constructor will try to acquire an exclusive
advisory lock on the file /tmp/coreArbiterAdvisoryLock.
If failed, it means that there may
be another server running, and then it will log error and exit.
The advisory lock will be released in the destructor function.

Using advisory lock can ensure that we only have one CoreArbiterServer
instance at a time.

This commit also remove sudo command in Makefile. Now user need to
first run make test and then again sudo make test.