### PR TITLE
Fix error handling in creaateNewServerConnection

### DIFF
--- a/src/CoreArbiterClient.cc
+++ b/src/CoreArbiterClient.cc
@@ -369,6 +369,7 @@ CoreArbiterClient::createNewServerConnection() {
         0) {
         std::string err = "Error connecting: " + std::string(strerror(errno));
         LOG(ERROR, "%s", err.c_str());
+        serverSocket = -1;  // Set serverSocket back to -1 if connection failed
         throw ClientException(err);
     }
 


### PR DESCRIPTION
Set severSocket back to -1 if connection failed! Otherwise future calls to setRequestedCores would incorrectly believe the connection has been established.