### PR TITLE
Fix bugs in CoreArbiter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,15 +68,20 @@ GTEST_DIR=../googletest/googletest
 TEST_LIBS=-Lobj/ -lCoreArbiter $(OBJECT_DIR)/libgtest.a
 INCLUDE+=-I${GTEST_DIR}/include
 
-test: $(OBJECT_DIR)/CoreArbiterServerTest $(OBJECT_DIR)/CoreArbiterClientTest
+test: $(OBJECT_DIR)/CoreArbiterServerTest $(OBJECT_DIR)/CoreArbiterClientTest  $(OBJECT_DIR)/CoreArbiterRequestTest
 	$(OBJECT_DIR)/CoreArbiterServerTest
 	$(OBJECT_DIR)/CoreArbiterClientTest
+	# The following test is built but must be run manually for now.
+	# $(OBJECT_DIR)/CoreArbiterRequestTest
 
 $(OBJECT_DIR)/CoreArbiterServerTest: $(OBJECT_DIR)/CoreArbiterServerTest.o $(OBJECT_DIR)/libgtest.a $(OBJECT_DIR)/libCoreArbiter.a
 	$(CXX) $(INCLUDE) $(CCFLAGS) $< $(GTEST_DIR)/src/gtest_main.cc $(TEST_LIBS) $(LIBS)  -o $@
 
 $(OBJECT_DIR)/CoreArbiterClientTest: $(OBJECT_DIR)/CoreArbiterClientTest.o $(OBJECT_DIR)/libgtest.a $(OBJECT_DIR)/libCoreArbiter.a
-	$(CXX) $(INCLUDE) $(CCFLAGS) $< $(GTEST_DIR)/src/gtest_main.cc $(TEST_LIBS) $(LIBS)  -o $@
+	$(CXX) $(INCLUDE) $(CCFLAGS) $< $(GTEST_DIR)/src/gtest_main.cc $(TEST_LIBS) $(LIBS) -o $@
+
+$(OBJECT_DIR)/CoreArbiterRequestTest: $(OBJECT_DIR)/CoreArbiterRequestTest.o $(OBJECT_DIR)/libCoreArbiter.a
+	$(CXX) $(INCLUDE) $(CCFLAGS) $^  $(LIBS)  -o $@
 
 $(OBJECT_DIR)/libgtest.a:
 	$(CXX) -I${GTEST_DIR}/include -I${GTEST_DIR} \

--- a/src/CoreArbiterClient.cc
+++ b/src/CoreArbiterClient.cc
@@ -461,9 +461,10 @@ CoreArbiterClient::readData(int socket, void* buf, size_t numBytes,
         LOG(ERROR, "%s", fullErrStr.c_str());
         throw ClientException(fullErrStr);
     } else if ((size_t)readBytes < numBytes) {
-        std::string fullErrStr =
-            err + ": Expected " + std::to_string(numBytes) +
-            " bytes but received " + std::to_string(readBytes);
+        std::string fullErrStr = err + " TID=" + std::to_string(sys->gettid()) +
+                                 ": Expected " + std::to_string(numBytes) +
+                                 " bytes but received " +
+                                 std::to_string(readBytes);
         LOG(ERROR, "%s", fullErrStr.c_str());
         throw ClientException(fullErrStr);
     }

--- a/src/CoreArbiterClient.cc
+++ b/src/CoreArbiterClient.cc
@@ -340,6 +340,7 @@ CoreArbiterClient::getNumProcessesOnServer() {
  */
 void
 CoreArbiterClient::createNewServerConnection() {
+    Lock lock(mutex);
     if (serverSocket != -1) {
         LOG(WARNING, "This thread already has a connection to the server.");
         return;
@@ -382,7 +383,6 @@ CoreArbiterClient::createNewServerConnection() {
     pid_t threadId = sys->gettid();
     sendData(serverSocket, &threadId, sizeof(pid_t), "Error sending thread ID");
 
-    Lock lock(mutex);
     if (!processStats) {
         // This is the first time this process is registering so we need to
         // set up the shared memory pages

--- a/src/CoreArbiterRequestTest.cc
+++ b/src/CoreArbiterRequestTest.cc
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <atomic>
+#include <thread>
+
+#include "CoreArbiterClient.h"
+#include "Logger.h"
+#include "PerfUtils/Cycles.h"
+#include "PerfUtils/Stats.h"
+#include "PerfUtils/TimeTrace.h"
+#include "PerfUtils/Util.h"
+
+/**
+ * This benchmark will rapidly increase and decrease the number of cores
+ * requested, to stress the core arbiter's allocation and deallocation
+ * mechanism.
+ */
+
+using CoreArbiter::CoreArbiterClient;
+using PerfUtils::Cycles;
+using PerfUtils::TimeTrace;
+using namespace CoreArbiter;
+
+#define NUM_TRIALS 100
+
+std::atomic<bool> end(false);
+
+/**
+ * This thread will block and unblock on the Core Arbiter's command.
+ */
+void
+coreExec(CoreArbiterClient* client) {
+    while (!end) {
+        client->blockUntilCoreAvailable();
+        while (!client->mustReleaseCore())
+            ;
+    }
+}
+
+/**
+ * This thread will request an increasing number of cores and then a decreasing
+ * number of cores.
+ */
+int
+main(int argc, const char** argv) {
+    const int MAX_CORES = std::thread::hardware_concurrency() - 1;
+    CoreArbiterClient* client = CoreArbiterClient::getInstance();
+
+    // Start up several threads to actually ramp up and down
+    for (int i = 0; i < MAX_CORES; i++)
+        (new std::thread(coreExec, std::ref(client)))->detach();
+
+    std::vector<uint32_t> coreRequest = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    for (int i = 0; i < NUM_TRIALS; i++) {
+        // First go up and then go down.
+        int j;
+        for (j = 1; j < MAX_CORES; j++) {
+            coreRequest[0] = j;
+            client->setRequestedCores(coreRequest);
+        }
+        for (; j > 0; j--) {
+            coreRequest[0] = j;
+            client->setRequestedCores(coreRequest);
+        }
+    }
+    coreRequest[0] = MAX_CORES;
+    client->setRequestedCores(coreRequest);
+    end.store(true);
+}

--- a/src/CoreArbiterServer.cc
+++ b/src/CoreArbiterServer.cc
@@ -433,6 +433,7 @@ CoreArbiterServer::handleEvents() {
             if (sys->close(socket) < 0) {
                 LOG(ERROR, "Error closing socket: %s", strerror(errno));
             }
+            timerFdToInfo.erase(socket);
         } else if (socket == terminationFd) {
             return false;
         } else {


### PR DESCRIPTION
1. Fix distributed deadlock on initialization.
2. Fix spurious closure of client connections.

See commit messages for details.