### PR TITLE
Various core arbiter updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ server
 # Misc files
 tags
 
+# Vim swap files
+.*.swp
+
 # Generated files
 obj/
 lib/

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ GTEST_DIR=../googletest/googletest
 TEST_LIBS=-Lobj/ -lCoreArbiter $(OBJECT_DIR)/libgtest.a
 INCLUDE+=-I${GTEST_DIR}/include
 
-test: $(OBJECT_DIR)/CoreArbiterServerTest $(OBJECT_DIR)/CoreArbiterClientTest  $(OBJECT_DIR)/CoreArbiterRequestTest
+test: $(OBJECT_DIR)/CoreArbiterServerTest $(OBJECT_DIR)/CoreArbiterClientTest  $(OBJECT_DIR)/CoreArbiterRequestTest $(OBJECT_DIR)/CoreArbiterRampDownTest
 	$(OBJECT_DIR)/CoreArbiterServerTest
 	$(OBJECT_DIR)/CoreArbiterClientTest
 	# The following test is built but must be run manually for now.
@@ -81,6 +81,9 @@ $(OBJECT_DIR)/CoreArbiterClientTest: $(OBJECT_DIR)/CoreArbiterClientTest.o $(OBJ
 	$(CXX) $(INCLUDE) $(CCFLAGS) $< $(GTEST_DIR)/src/gtest_main.cc $(TEST_LIBS) $(LIBS) -o $@
 
 $(OBJECT_DIR)/CoreArbiterRequestTest: $(OBJECT_DIR)/CoreArbiterRequestTest.o $(OBJECT_DIR)/libCoreArbiter.a
+	$(CXX) $(INCLUDE) $(CCFLAGS) $^  $(LIBS)  -o $@
+
+$(OBJECT_DIR)/CoreArbiterRampDownTest: $(OBJECT_DIR)/CoreArbiterRampDownTest.o $(OBJECT_DIR)/libCoreArbiter.a
 	$(CXX) $(INCLUDE) $(CCFLAGS) $^  $(LIBS)  -o $@
 
 $(OBJECT_DIR)/libgtest.a:

--- a/src/CoreArbiterClient.cc
+++ b/src/CoreArbiterClient.cc
@@ -51,13 +51,16 @@ bool CoreArbiterClient::testingSkipConnectionSetup = false;
 // frequently cast their 64-bit arguments into uint32_t explicitly: we will
 // help perform the casting internally.
 static inline void
-timeTrace(const char* format, uint64_t arg0 = 0, uint64_t arg1 = 0,
-          uint64_t arg2 = 0, uint64_t arg3 = 0) {
+timeTrace(const char* format,
+		uint64_t arg0 = 0, uint64_t arg1 = 0, uint64_t arg2 = 0,
+		uint64_t arg3 = 0)
+{
 #if TIME_TRACE
-    TimeTrace::record(format, uint32_t(arg0), uint32_t(arg1), uint32_t(arg2),
-                      uint32_t(arg3));
+	TimeTrace::record(format, uint32_t(arg0), uint32_t(arg1),
+			uint32_t(arg2), uint32_t(arg3));
 #endif
 }
+
 
 /**
  * Private constructor because CoreArbiterClient is a singleton class. The

--- a/src/CoreArbiterClient.cc
+++ b/src/CoreArbiterClient.cc
@@ -51,16 +51,13 @@ bool CoreArbiterClient::testingSkipConnectionSetup = false;
 // frequently cast their 64-bit arguments into uint32_t explicitly: we will
 // help perform the casting internally.
 static inline void
-timeTrace(const char* format,
-		uint64_t arg0 = 0, uint64_t arg1 = 0, uint64_t arg2 = 0,
-		uint64_t arg3 = 0)
-{
+timeTrace(const char* format, uint64_t arg0 = 0, uint64_t arg1 = 0,
+          uint64_t arg2 = 0, uint64_t arg3 = 0) {
 #if TIME_TRACE
-	TimeTrace::record(format, uint32_t(arg0), uint32_t(arg1),
-			uint32_t(arg2), uint32_t(arg3));
+    TimeTrace::record(format, uint32_t(arg0), uint32_t(arg1), uint32_t(arg2),
+                      uint32_t(arg3));
 #endif
 }
-
 
 /**
  * Private constructor because CoreArbiterClient is a singleton class. The

--- a/src/CoreArbiterClientTest.cc
+++ b/src/CoreArbiterClientTest.cc
@@ -16,8 +16,8 @@
 #define private public
 #define protected public
 
-#include "ArbiterClientShim.h"
 #include "CoreArbiterClient.h"
+#include "ArbiterClientShim.h"
 #include "Logger.h"
 #include "MockSyscall.h"
 

--- a/src/CoreArbiterClientTest.cc
+++ b/src/CoreArbiterClientTest.cc
@@ -120,7 +120,6 @@ TEST_F(CoreArbiterClientTest, mustReleaseCore) {
     int coreId = 0;
 
     client.coreId = coreId;
-    processStats.coreReleaseRequestCount = 1;
     processStats.threadCommunicationBlocks[coreId].coreReleaseRequested = true;
     ASSERT_TRUE(client.mustReleaseCore());
 
@@ -144,7 +143,6 @@ TEST_F(CoreArbiterClientTest, blockUntilCoreAvailable_establishConnection) {
 
 TEST_F(CoreArbiterClientTest, blockUntilCoreAvailable_alreadyExclusive) {
     connectClient();
-    client.processStats->coreReleaseRequestCount = 0;
     client.coreId = 1;
     client.processStats->numOwnedCores = 1;
 
@@ -153,7 +151,6 @@ TEST_F(CoreArbiterClientTest, blockUntilCoreAvailable_alreadyExclusive) {
     EXPECT_EQ(client.processStats->numOwnedCores, 1u);
 
     // This time thread should block because it owes the server a core
-    client.processStats->coreReleaseRequestCount = 1;
     processStats.threadCommunicationBlocks[client.coreId].coreReleaseRequested =
         true;
     int coreId = 2;
@@ -162,7 +159,6 @@ TEST_F(CoreArbiterClientTest, blockUntilCoreAvailable_alreadyExclusive) {
     EXPECT_EQ(client.processStats->numOwnedCores, 1u);
 
     // Same test, but this time with a pending release
-    client.processStats->coreReleaseRequestCount = 1;
     send(serverSocket, &coreId, sizeof(int), 0);
     EXPECT_EQ(client.blockUntilCoreAvailable(), 2);
     EXPECT_EQ(client.processStats->numOwnedCores, 1u);

--- a/src/CoreArbiterCommon.h
+++ b/src/CoreArbiterCommon.h
@@ -46,10 +46,6 @@ struct ThreadCommunicationBlock {
  * can write to the shared memory.
  */
 struct ProcessStats {
-    // A monotonically increasing count of the number of cores the server has
-    // requested that a process release in the client object's lifetime.
-    std::atomic<uint64_t> coreReleaseRequestCount;
-
     // A monotonically increasing count of the number of times the server has
     // forceably moved a thread belonging to this process to the unmanaged core
     // because it did not release a core when requested to.
@@ -75,8 +71,7 @@ struct ProcessStats {
     ThreadCommunicationBlock threadCommunicationBlocks[MAX_SUPPORTED_CORES];
 
     ProcessStats()
-        : coreReleaseRequestCount(0),
-          preemptedCount(0),
+        : preemptedCount(0),
           unpreemptedCount(0),
           numBlockedThreads(0),
           numOwnedCores(0) {

--- a/src/CoreArbiterRampDownTest.cc
+++ b/src/CoreArbiterRampDownTest.cc
@@ -1,0 +1,89 @@
+#include <stdio.h>
+#include <atomic>
+#include <thread>
+
+#include "CoreArbiterClient.h"
+#include "Logger.h"
+#include "PerfUtils/Cycles.h"
+#include "PerfUtils/Stats.h"
+#include "PerfUtils/TimeTrace.h"
+#include "PerfUtils/Util.h"
+
+/**
+ * This benchmark will rapidly increase and decrease the number of cores
+ * requested, to stress the core arbiter's allocation and deallocation
+ * mechanism.
+ */
+
+// Uncomment the following line to make this benchmark pause for 2 seconds
+// between allocations so that we observe the order of allocation and
+// de-allocation.
+// #define PAUSE_AT_ALLOCATION 1
+
+using CoreArbiter::CoreArbiterClient;
+using PerfUtils::Cycles;
+using PerfUtils::TimeTrace;
+using namespace CoreArbiter;
+
+#define NUM_TRIALS 100
+
+std::atomic<bool> end(false);
+std::atomic<uint32_t> numActiveCores;
+
+/**
+ * This thread will block and unblock on the Core Arbiter's command.
+ */
+void
+coreExec(CoreArbiterClient* client) {
+    while (!end) {
+        client->blockUntilCoreAvailable();
+        numActiveCores++;
+        while (!client->mustReleaseCore())
+            ;
+        numActiveCores--;
+    }
+}
+
+// Helper function for tests with timing dependencies, so that we wait for a
+// finite amount of time in the case of a bug causing an infinite loop.
+static void
+limitedTimeWait(std::function<bool()> condition, int numIterations = 1000) {
+    for (int i = 0; i < numIterations; i++) {
+        if (condition()) {
+            return;
+        }
+        usleep(1000);
+    }
+    fprintf(stderr, "Failed to wait for condition to be true.\n");
+}
+
+/**
+ * This thread will request a large number of cores, and then gradually request
+ * a smaller number of cores, verifying that we eventually get
+ * mustReleaseCore() called on us.
+ */
+int
+main(int argc, const char** argv) {
+    const uint32_t MAX_CORES = std::thread::hardware_concurrency() - 1;
+    CoreArbiterClient* client = CoreArbiterClient::getInstance();
+
+    // Start up several threads to actually ramp up and down
+    for (uint32_t i = 0; i < MAX_CORES; i++)
+        (new std::thread(coreExec, std::ref(client)))->detach();
+
+    std::vector<uint32_t> coreRequest = {MAX_CORES, 0, 0, 0, 0, 0, 0, 0};
+    client->setRequestedCores(coreRequest);
+    // Wait until we actually have that many cores
+    while (numActiveCores.load() != coreRequest[0])
+        ;
+
+    // Then, verify that we can step down, with a limited time wait.
+    coreRequest[0] = 0;
+    client->setRequestedCores(coreRequest);
+    limitedTimeWait([]() -> bool { return numActiveCores == 0; });
+
+    // Go back up and exit.
+    coreRequest[0] = MAX_CORES;
+    client->setRequestedCores(coreRequest);
+    end.store(true);
+}

--- a/src/CoreArbiterRequestTest.cc
+++ b/src/CoreArbiterRequestTest.cc
@@ -30,6 +30,11 @@
  * mechanism.
  */
 
+// Uncomment the following line to make this benchmark pause for 2 seconds
+// between allocations so that we observe the order of allocation and
+// de-allocation.
+// #define PAUSE_AT_ALLOCATION 1
+
 using CoreArbiter::CoreArbiterClient;
 using PerfUtils::Cycles;
 using PerfUtils::TimeTrace;
@@ -71,10 +76,16 @@ main(int argc, const char** argv) {
         for (j = 1; j < MAX_CORES; j++) {
             coreRequest[0] = j;
             client->setRequestedCores(coreRequest);
+#if PAUSE_AT_ALLOCATION
+            sleep(2);
+#endif
         }
         for (; j > 0; j--) {
             coreRequest[0] = j;
             client->setRequestedCores(coreRequest);
+#if PAUSE_AT_ALLOCATION
+            sleep(2);
+#endif
         }
     }
     coreRequest[0] = MAX_CORES;

--- a/src/CoreArbiterServer.cc
+++ b/src/CoreArbiterServer.cc
@@ -880,7 +880,7 @@ CoreArbiterServer::cleanupConnection(int socket) {
 
     // Update state pertaining to cores
     if (thread->state == RUNNING_MANAGED) {
-        managedThreads.erase(thread);
+        managedThreads.erase(std::remove(managedThreads.begin(), managedThreads.end(), thread), managedThreads.end());
         thread->core->managedThread = NULL;
         thread->core->threadRemovalTime = Cycles::rdtsc();
         process->stats->numOwnedCores--;
@@ -1721,7 +1721,7 @@ CoreArbiterServer::moveThreadToManagedCore(struct ThreadInfo* thread,
     changeThreadState(thread, RUNNING_MANAGED);
     thread->core = core;
     core->managedThread = thread;
-    managedThreads.insert(thread);
+    managedThreads.push_back(thread);
     thread->process->stats->numOwnedCores++;
     stats->numUnoccupiedCores--;
 
@@ -1779,7 +1779,7 @@ CoreArbiterServer::removeThreadFromManagedCore(struct ThreadInfo* thread,
     thread->core->managedThread = NULL;
     thread->core->threadRemovalTime = Cycles::rdtsc();
     thread->core = NULL;
-    managedThreads.erase(thread);
+    managedThreads.erase(std::remove(managedThreads.begin(), managedThreads.end(), thread), managedThreads.end());
 
     stats->numUnoccupiedCores++;
 }

--- a/src/CoreArbiterServer.h
+++ b/src/CoreArbiterServer.h
@@ -243,6 +243,7 @@ class CoreArbiterServer {
     void cleanupConnection(int socket);
     CoreInfo* findGoodCoreForProcess(ProcessInfo* process,
                                      std::deque<struct CoreInfo*>& candidates);
+    void wakeupThread(ThreadInfo* thread, CoreInfo* core);
     void distributeCores();
     void requestCoreRelease(struct CoreInfo* core);
 

--- a/src/CoreArbiterServer.h
+++ b/src/CoreArbiterServer.h
@@ -344,7 +344,7 @@ class CoreArbiterServer {
     uint64_t cpusetUpdateTimeout;
 
     // The set of the threads currently running on cores in managedCores.
-    std::unordered_set<struct ThreadInfo*> managedThreads;
+    std::vector<struct ThreadInfo*> managedThreads;
 
     // The smallest index in the vector is the highest priority and the first
     // entry in the deque is the next process that should receive a core at

--- a/src/CoreArbiterServer.h
+++ b/src/CoreArbiterServer.h
@@ -201,10 +201,6 @@ class CoreArbiterServer {
         // blocks and can be assigned a new core.
         std::unordered_set<CoreInfo*> coresPreemptedFrom;
 
-        // A monotonically increasing counter of the number of cores this
-        // process has owned and then released.
-        uint64_t coreReleaseCount;
-
         // How many cores this process desires at each priority level. Smaller
         // indexes mean higher priority.
         std::vector<uint32_t> desiredCorePriorities;
@@ -220,18 +216,16 @@ class CoreArbiterServer {
             : id(id),
               sharedMemFd(sharedMemFd),
               stats(stats),
-              coreReleaseCount(0),
               desiredCorePriorities(NUM_PRIORITIES) {}
     };
 
     /**
-     * A snapshot of the state of a process at the time that a preemption timer
-     * is set. This prevents the server from preempting a thread that was just
-     * asked to yield if the process complied with a prior release request.
+     * Data structure that stores a process and the core it was asked to
+     * relinquish. This prevents the server from preempting a thread that has
+     * already yielded.
      */
     struct TimerInfo {
         pid_t processId;
-        uint64_t coreReleaseRequestCount;
         CoreInfo* coreInfo;
     };
 

--- a/src/CoreArbiterServer.h
+++ b/src/CoreArbiterServer.h
@@ -229,6 +229,8 @@ class CoreArbiterServer {
     void coresRequested(int socket);
     void timeoutThreadPreemption(int timerFd);
     void cleanupConnection(int socket);
+    CoreInfo* findGoodCoreForProcess(ProcessInfo* process,
+                                     std::deque<struct CoreInfo*>& candidates);
     void distributeCores();
     void requestCoreRelease(struct CoreInfo* core);
 
@@ -304,7 +306,7 @@ class CoreArbiterServer {
     // cpuset. At startup, this vector contains all cores controlled by the
     // arbiter. It shrinks as cores are requested and grows when cores are
     // unused for an extended period.
-    std::vector<struct CoreInfo*> unmanagedCores;
+    std::deque<struct CoreInfo*> unmanagedCores;
 
     // The file used to change which cores belong to the unmanaged cpuset.
     std::ofstream unmanagedCpusetCpus;

--- a/src/CoreArbiterServer.h
+++ b/src/CoreArbiterServer.h
@@ -154,6 +154,11 @@ class CoreArbiterServer {
         // thread is not running on a managed core.
         struct CoreInfo* core;
 
+        // A pointer to the managed core this thread was running before it was
+        // preempted. If this thread becomes unpreempted before it blocks, it
+        // must return to this core.
+        struct CoreInfo* corePreemptedFrom;
+
         // The current state of this thread. When a thread first registers it
         // is assumed to be RUNNING_UNMANAGED.
         ThreadState state;
@@ -165,6 +170,7 @@ class CoreArbiterServer {
               process(process),
               socket(socket),
               core(NULL),
+              corePreemptedFrom(NULL),
               state(RUNNING_UNMANAGED) {}
     };
 
@@ -188,6 +194,12 @@ class CoreArbiterServer {
         // A pointer to shared memory that is used to communicate information
         // to this process.
         struct ProcessStats* stats;
+
+        // The set of cores that threads belonging to this process have been
+        // timeout-preempted from. We must ensure that no threads from this
+        // process are scheduled onto this core until the preempted thread
+        // blocks and can be assigned a new core.
+        std::unordered_set<CoreInfo*> coresPreemptedFrom;
 
         // A monotonically increasing counter of the number of cores this
         // process has owned and then released.

--- a/src/CoreArbiterServerMain.cc
+++ b/src/CoreArbiterServerMain.cc
@@ -13,8 +13,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <string.h>
 #include "CoreArbiterServer.h"
+#include <string.h>
 #include "Logger.h"
 #include "PerfUtils/Util.h"
 

--- a/src/CoreArbiterServerTest.cc
+++ b/src/CoreArbiterServerTest.cc
@@ -79,7 +79,7 @@ class CoreArbiterServerTest : public ::testing::Test {
         process->threadStateToSet[state].insert(thread);
         server.threadSocketToInfo[socket] = thread;
         if (state == CoreArbiterServer::RUNNING_MANAGED) {
-            server.managedThreads.insert(thread);
+            server.managedThreads.push_back(thread);
             process->stats->numOwnedCores++;
             thread->core = core;
             core->managedThread = thread;
@@ -433,7 +433,7 @@ TEST_F(CoreArbiterServerTest, distributeCores_niceToHaveSinglePriority) {
     // Don't give processes more cores at this priority than they've asked for
     ThreadInfo* removedThread = server.managedCores[0]->managedThread;
     removedThread->process->desiredCorePriorities[7] = 0;
-    server.managedThreads.erase(removedThread);
+    server.managedThreads.erase(std::remove(server.managedThreads.begin(), server.managedThreads.end(), removedThread));
     server.managedCores[0]->managedThread = NULL;
     server.distributeCores();
     ProcessInfo* otherProcess =
@@ -653,7 +653,7 @@ TEST_F(CoreArbiterServerTest, cleanupConnection) {
         process->threadStateToSet[CoreArbiterServer::RUNNING_MANAGED].empty());
     ASSERT_EQ(server.threadSocketToInfo.find(1),
               server.threadSocketToInfo.end());
-    ASSERT_EQ(server.managedThreads.find(managedThread),
+    ASSERT_EQ(std::find(server.managedThreads.begin(), server.managedThreads.end(), managedThread),
               server.managedThreads.end());
     ASSERT_EQ(core->managedThread, (ThreadInfo*)NULL);
     ASSERT_EQ(process->stats->numOwnedCores, 0u);

--- a/src/CoreArbiterServerTest.cc
+++ b/src/CoreArbiterServerTest.cc
@@ -210,7 +210,8 @@ TEST_F(CoreArbiterServerTest, threadBlocking_basic) {
     ASSERT_EQ(processStats.numBlockedThreads, 0u);
 
     // If the server has requested cores back, this call succeeds
-    processStats.threadCommunicationBlocks[server.managedCores[0]->id].coreReleaseRequested = true;
+    processStats.threadCommunicationBlocks[server.managedCores[0]->id]
+        .coreReleaseRequested = true;
     server.threadBlocking(socket);
     ASSERT_EQ(thread->state, CoreArbiterServer::BLOCKED);
     ASSERT_EQ(processStats.numBlockedThreads, 1u);
@@ -233,7 +234,8 @@ TEST_F(CoreArbiterServerTest, threadBlocking_preemptedThread) {
     pid_t threadId = 1;
     int socket = 2;
     ProcessStats processStats;
-    processStats.threadCommunicationBlocks[server.managedCores[0]->id].coreReleaseRequested = true;
+    processStats.threadCommunicationBlocks[server.managedCores[0]->id]
+        .coreReleaseRequested = true;
     ProcessInfo* process = createProcess(server, processId, &processStats);
     ThreadInfo* thread = createThread(server, threadId, process, socket,
                                       CoreArbiterServer::RUNNING_PREEMPTED);
@@ -428,7 +430,9 @@ TEST_F(CoreArbiterServerTest, distributeCores_niceToHaveSinglePriority) {
     // Don't give processes more cores at this priority than they've asked for
     ThreadInfo* removedThread = server.managedCores[0]->managedThread;
     removedThread->process->desiredCorePriorities[7] = 0;
-    server.managedThreads.erase(std::remove(server.managedThreads.begin(), server.managedThreads.end(), removedThread));
+    server.managedThreads.erase(std::remove(server.managedThreads.begin(),
+                                            server.managedThreads.end(),
+                                            removedThread));
     server.managedCores[0]->managedThread = NULL;
     server.distributeCores();
     ProcessInfo* otherProcess =
@@ -478,11 +482,18 @@ TEST_F(CoreArbiterServerTest, distributeCores_niceToHaveMultiplePriorities) {
     // Higher priority threads preempt lower priority threads
     highPriorityProcess->desiredCorePriorities[6] = 4;
     server.distributeCores();
-    ASSERT_TRUE(
-            lowPriorityProcess->stats->threadCommunicationBlocks[server.managedCores[0]->id].coreReleaseRequested ||
-            lowPriorityProcess->stats->threadCommunicationBlocks[server.managedCores[1]->id].coreReleaseRequested ||
-            lowPriorityProcess->stats->threadCommunicationBlocks[server.managedCores[2]->id].coreReleaseRequested ||
-            lowPriorityProcess->stats->threadCommunicationBlocks[server.managedCores[3]->id].coreReleaseRequested);
+    ASSERT_TRUE(lowPriorityProcess->stats
+                    ->threadCommunicationBlocks[server.managedCores[0]->id]
+                    .coreReleaseRequested ||
+                lowPriorityProcess->stats
+                    ->threadCommunicationBlocks[server.managedCores[1]->id]
+                    .coreReleaseRequested ||
+                lowPriorityProcess->stats
+                    ->threadCommunicationBlocks[server.managedCores[2]->id]
+                    .coreReleaseRequested ||
+                lowPriorityProcess->stats
+                    ->threadCommunicationBlocks[server.managedCores[3]->id]
+                    .coreReleaseRequested);
     ASSERT_EQ(server.timerFdToInfo.size(), 1u);
     ASSERT_EQ(highPriorityProcess->stats->numOwnedCores, 3u);
 
@@ -651,7 +662,8 @@ TEST_F(CoreArbiterServerTest, cleanupConnection) {
         process->threadStateToSet[CoreArbiterServer::RUNNING_MANAGED].empty());
     ASSERT_EQ(server.threadSocketToInfo.find(1),
               server.threadSocketToInfo.end());
-    ASSERT_EQ(std::find(server.managedThreads.begin(), server.managedThreads.end(), managedThread),
+    ASSERT_EQ(std::find(server.managedThreads.begin(),
+                        server.managedThreads.end(), managedThread),
               server.managedThreads.end());
     ASSERT_EQ(core->managedThread, (ThreadInfo*)NULL);
     ASSERT_EQ(process->stats->numOwnedCores, 0u);

--- a/src/CoreArbiterServerTest.cc
+++ b/src/CoreArbiterServerTest.cc
@@ -274,6 +274,7 @@ TEST_F(CoreArbiterServerTest, threadBlocking_movePreemptedThread) {
                                        server.managedCores[0]);
     ThreadInfo* thread2 = createThread(server, threadId2, process, socket2,
                                        CoreArbiterServer::RUNNING_PREEMPTED);
+    thread2->corePreemptedFrom = server.managedCores[0];
 
     // When a process with a preempted thread gives up an managed core, the
     // preempted thread should be moved back to that core


### PR DESCRIPTION
This set of commits introduces the following changes.

0. New integration test to ensure that cores ramp down correctly.
1. Processes choose cores with loose hyperthread affinity
2. `threadBlocking` method is more explicit in how it handles each possible thread state.
3. Threads which were not asked to yield their cores will immediately return from `blockUntilCoreAvailable`.
4. Thread A from process X cannot run on Core Y if Thread B from process X was pre-empted from Core Y and hasn't yet blocked.