### PR TITLE
Makefile: Allow to specify extra cxxflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CXX ?= g++
 CCFLAGS=-g -Wall -Wformat=2 -Wextra -Wwrite-strings \
 -Wno-unused-parameter -Wmissing-format-attribute -Wno-non-template-friend \
 -Woverloaded-virtual -Wcast-qual -Wcast-align -Wconversion -fomit-frame-pointer \
--std=c++11 -fPIC -O3
+-std=c++11 -fPIC -O3 $(EXTRA_CXXFLAGS)
 
 # Output directories
 OBJECT_DIR = obj


### PR DESCRIPTION
The link errors about undefined references to symbols that involve
types in the std::__cxx11 namespace. It is useful to allow to specify
the extra cxxflags such as 'EXTRA_CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0'
to handle this sort of atempt to link together object files that were
compiled with different values for the _GLIBCXX_USE_CXX11_ABI macro.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>