### PR TITLE
Makefile: Added -Wno-unused-result flag of GCC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CXX ?= g++
 CCFLAGS=-g -Wall -Wformat=2 -Wextra -Wwrite-strings \
 -Wno-unused-parameter -Wmissing-format-attribute -Wno-non-template-friend \
 -Woverloaded-virtual -Wcast-qual -Wcast-align -Wconversion -fomit-frame-pointer \
--std=c++11 -fPIC -O3 $(EXTRA_CXXFLAGS)
+ -Wno-unused-result -std=c++11 -fPIC -O3 $(EXTRA_CXXFLAGS)
 
 # Output directories
 OBJECT_DIR = obj


### PR DESCRIPTION
Fixed issue #24.

This commit is to ignore the warning message while building the source code.

```bash
src/CoreArbiterServer.cc:
warning: ignoring return value of ‘int fscanf(FILE*, const char*, ...)’,
declared with attribute warn_unused_result [-Wunused-result]
```

Signed-off-by: Geunsik Lim <leemgs@gmail.com>